### PR TITLE
Enable reduction of trees spanning >=1 slice(s) of on-device GPU memory..

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ The Merkle root of the whole dataset can then be calculated as the Merkle root o
 
 Overall, the program is not terribly quick, but I was curious to see how much time was being spent processing on the GPU, and: 
 
-| Platform | Mapping | Reduction (by Subgroups) | Effective Hashrate |
-| ------------- | ------------- | ------------- | ------------- |
-| Steam Deck (LCD)  | ~252MB in ~190ms = ~1.295GB/s  | 256MB in ~800ms = 320MB/s | ~20.9MH/s |
-| Intel Iris Xe Graphics (12th Gen, integrated) | ~252MB in ~80ms = ~3.039GB/s  | 256MB in 300ms = ~853.33MB/s | ~55.9MH/s |
-| nVidia RTX 4070 Super (via Thunderbolt) | ~252MB in ~265ms = ~951MB/s  | 256MB in _<16ms_ = ~16GB/s | ~1.118 GH/s |
+| Platform | Mapping | Reduction (w/Subgroups) | Effective Hashrate | Reduction (w/o Subgroups) | Effective Hashrate |
+| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+| Steam Deck (LCD)  | ~252MB in ~190ms = ~1.295GB/s  | 256MB in ~800ms = ~320MB/s | ~20.9MH/s | 256MB in ~250ms = ~1GB/s | ~67.1MH/s |
+| Intel Iris Xe Graphics (12th Gen, integrated) | ~252MB in ~80ms = ~3.039GB/s  | 256MB in 300ms = ~853.33MB/s | ~55.9MH/s | 256MB in ~110ms = ~2.3GB/s | ~152.5MH/s  |
+| nVidia RTX 4070 Super (via Thunderbolt) | ~252MB in ~265ms = ~951MB/s  | 256MB in _<16ms_ = ~16GB/s | ~1.082 GH/s | 256MB in _<9ms_ = ~16GB/s | ~1.864GH/s |
 
 I had only intended on including the numbers from the Steam Deck (since it is a relatively standardised platform) but the results of running the same tests - using the same dataset - against an RTX 4070 Super, even one connected as an eGPU, were .. eyebrow-raising.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Vulkan Merkle Roots
 
 ## Summary
-A program to demonstrate the calculation/resolution of the roots of [Merkle/hash trees](https://en.wikipedia.org/wiki/Merkle_tree) of arbitrary inputs on GPUs via the [Vulkan API](https://en.wikipedia.org/wiki/Vulkan).
+A program to demonstrate the calculation of the roots of [Merkle/hash trees](https://en.wikipedia.org/wiki/Merkle_tree) of arbitrary inputs on GPUs via the [Vulkan API](https://en.wikipedia.org/wiki/Vulkan).
 
 ## Components
 ### `vkmr`
@@ -52,7 +52,7 @@ Pulling a proof-of-concept together, using OpenCL, really wasn't too difficult, 
 * Not have any dependencies beyond Vulkan and the C++ Standard Library.
 
 ### Non-Goals
-* Performance: where there is a choice between doing something on the GPU and doing it more performantly on the CPU, do it on the GPU (the aim being, recall, that the Merkle root calculation runs entirely asynchronously with respect to whatever's happening on the CPU).
+* Performance: i.e., where there is a choice between doing something on the GPU and doing it more performantly on the CPU, prefer to do it on the GPU (the aim being, recall, that the Merkle root calculation runs entirely asynchronously with respect to whatever's happening on the CPU).
 
 ### Choices
 

--- a/src/shaders/SHA-256.comp
+++ b/src/shaders/SHA-256.comp
@@ -25,9 +25,9 @@
 // Layouts
 //
 
-#ifdef _SHA_256_N_
 layout (local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
+#ifdef _SHA_256_N_
 layout(push_constant, std430) uniform pc {
     uint offset;
     uint bound;
@@ -54,12 +54,6 @@ layout(std430, set = 0, binding = 2) writeonly buffer result_layout
 #extension GL_KHR_shader_subgroup_basic : enable
 #extension GL_KHR_shader_subgroup_shuffle_relative: enable
 
-layout(constant_id = 0) const uint localSizeX = 64;
-layout(constant_id = 1) const uint localSizeY = 1;
-layout(constant_id = 2) const uint localSizeZ = 1;
-
-layout (local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
-
 layout(push_constant, std430) uniform pc {
     uint offset;
     uint pairs;
@@ -69,6 +63,7 @@ layout(push_constant, std430) uniform pc {
 };
 #else
 layout(push_constant, std430) uniform pc {
+    uint offset;
     uint pass;
     uint delta;
     uint bound;
@@ -397,7 +392,7 @@ void main() {
 #else
 void main() {
     // Bounds check
-    const uint idx = gl_GlobalInvocationID.x << pass;
+    const uint idx = (gl_GlobalInvocationID.x + offset) << pass;
     if (idx > bound){
         return;
     }


### PR DESCRIPTION
..where the GPU does _not_ support subgroup relative shuffle operations.